### PR TITLE
Ignore virtual folders, newsgroup items and RSS feeds.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -363,6 +363,11 @@ net.streiff.unreadbadge = function()
       let accountEnumerator = accounts.enumerate();
       let ignoreMask = 0;
 
+      ignoreMask |= nsMsgFolderFlags.Newsgroup;
+      ignoreMask |= nsMsgFolderFlags.NewsHost;
+      ignoreMask |= nsMsgFolderFlags.Virtual;
+      ignoreMask |= nsMsgFolderFlags.Subscribed;
+
       if (Services.prefs.getBoolPref(prefsPrefix + "ignoreJunk"))
          ignoreMask |= nsMsgFolderFlags.Junk;
       if (Services.prefs.getBoolPref(prefsPrefix + "ignoreDrafts"))
@@ -381,11 +386,12 @@ net.streiff.unreadbadge = function()
             and give us all the unread messages in this account, right? Wrong!
             Apparently you have to get all subfolders that are inboxes and do
             getNumUnread(true) on *those*. */
-         totalCount += getUnreadCountForFolder(rootFolder, ignoreMask);
+         if (((rootFolder.flags & ignoreMask) == 0) && (account.incomingServer.type != "rss"))
+            totalCount += getUnreadCountForFolder(rootFolder, ignoreMask);
       }
       return totalCount;
    }
- 
+
    var getUnreadCountForFolder = function(folder, ignoreMask)
    {
       var totalCount = 0;


### PR DESCRIPTION
Ignore new messages in virtual folders (avoids double-counts), new newsgroup items, and new RSS feed items.
