### PR TITLE
Optionally count primary inbox only.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -49,7 +49,7 @@ net.streiff.unreadbadge = function ()
    var setDefaultPreferences = function ()
    {
       let prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-      let branch = prefs.getBranch(prefsPrefix);
+      let branch = prefs.getDefaultBranch(prefsPrefix);
       for (let key in defaultPrefs) {
          if (defaultPrefs.hasOwnProperty(key)) {
             let value = defaultPrefs[key];

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -18,43 +18,10 @@ net.streiff.unreadbadge = function ()
    const Cc = Components.classes;
    const Ci = Components.interfaces;
 
-   /* See http://mxr.mozilla.org/mozilla1.8.0/source/mailnews/base/public/nsMsgFolderFlags.h
+   /* See https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsMsgFolderFlagType
    for what all of these mean.
     */
-   const nsMsgFolderFlags =
-   {
-      Newsgroup : 0x00000001,
-      NewsHost : 0x00000002,
-      Mail : 0x00000004,
-      Directory : 0x00000008,
-      Elided : 0x00000010,
-      Virtual : 0x00000020,
-      Subscribed : 0x00000040,
-      Unused2 : 0x00000080,
-      Trash : 0x00000100,
-      SentMail : 0x00000200,
-      Drafts : 0x00000400,
-      Queue : 0x00000800,
-      Inbox : 0x00001000,
-      ImapBox : 0x00002000,
-      Unused3 : 0x00004000,
-      ProfileGroup : 0x00008000,
-      Unused4 : 0x00010000,
-      GotNew : 0x00020000,
-      ImapServer : 0x00040000,
-      ImapPersonal : 0x00080000,
-      ImapPublic : 0x00100000,
-      ImapOtherUser : 0x00200000,
-      Templates : 0x00400000,
-      PersonalShared : 0x00800000,
-      ImapNoselect : 0x01000000,
-      CreatedOffline : 0x02000000,
-      ImapNoinferiors : 0x04000000,
-      Offline : 0x08000000,
-      OfflineEvents : 0x10000000,
-      CheckNew : 0x20000000,
-      Junk : 0x40000000
-   };
+   const nsMsgFolderFlags = Ci.nsMsgFolderFlags;
 
    const prefsPrefix = "extensions.unreadbadge.";
    const defaultPrefs =

--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,1 +1,1 @@
-# Nothing here!
+content		unread-badge		content/

--- a/content/options.xul
+++ b/content/options.xul
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://messenger/skin/preferences/preferences.css" type="text/css"?>
+
+<prefwindow id="window" title="Unread Badge Options" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+	<prefpane id="pane">
+		<preferences>
+			<preference id="pref-inboxOnly" name="extensions.unreadbadge.inboxOnly" type="bool"/>
+		</preferences>
+
+		<checkbox preference="pref-inboxOnly" label="Count primary inbox only"/>
+	</prefpane>
+</prefwindow>

--- a/install.rdf
+++ b/install.rdf
@@ -15,5 +15,6 @@
 		</em:targetApplication>
 		<em:targetPlatform>WINNT</em:targetPlatform>
 		<em:bootstrap>true</em:bootstrap>
+		<em:optionsURL>chrome://unread-badge/content/options.xul</em:optionsURL>
 	</Description>
 </RDF>

--- a/install.rdf
+++ b/install.rdf
@@ -10,7 +10,7 @@
 			<Description>
 				<em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
 				<em:minVersion>10.0</em:minVersion>
-				<em:maxVersion>60.*</em:maxVersion>
+				<em:maxVersion>66.0</em:maxVersion>
 			</Description>
 		</em:targetApplication>
 		<em:targetPlatform>WINNT</em:targetPlatform>


### PR DESCRIPTION
Adds configurable option to count primary inbox only.

There's also a bug fix so that default preferences no longer overwrite user preferences at each start-up. The wrong preferences branch was being used.